### PR TITLE
Updated a (broken) url to another version of zlib

### DIFF
--- a/zlib/README.md
+++ b/zlib/README.md
@@ -1,9 +1,9 @@
 How to compile
 ----
 
-	wget http://zlib.net/zlib-1.2.7.tar.gz
-	tar xvf zlib-1.2.7.tar.gz
-	cd zlib-1.2.7
+	wget http://zlib.net/zlib-1.2.8.tar.gz
+	tar xvf zlib-1.2.8.tar.gz
+	cd zlib-1.2.8
 	CC=x86_64-nacl-gcc ./configure --prefix=/usr/x86_64-nacl
 	make
 	sudo make install


### PR DESCRIPTION
The 1.2.7 version of zlib is not available anymore, but 1.2.8 is.
